### PR TITLE
Stick to bbmap version 37.17

### DIFF
--- a/atlas/envs/required_packages.yaml
+++ b/atlas/envs/required_packages.yaml
@@ -5,7 +5,7 @@ channels:
     - r
 dependencies:
     - python=3.5
-    - bbmap
+    - bbmap=37.17
     - bzip2
     - click
     - diamond


### PR DESCRIPTION
Bbduk2.sh seems to be removed in the latest version, so with this fix it is still present.