### PR TITLE
generate read stats for all steps

### DIFF
--- a/atlas/rules/assemble.snakefile
+++ b/atlas/rules/assemble.snakefile
@@ -429,9 +429,7 @@ rule finalize_QC:
     threads:
         1
     shell:
-        "{SHPFXS} mv {input} {output}"
-
-
+        "{SHPFXS} cp {input} {output}"
 
 
 

--- a/atlas/rules/assemble.snakefile
+++ b/atlas/rules/assemble.snakefile
@@ -7,7 +7,7 @@ import warnings
 
 
 
-localrules: postprocess_after_decontamination,rename_megahit_output,rename_spades_output,initialize_checkm,init_QC
+localrules: postprocess_after_decontamination,rename_megahit_output,rename_spades_output,initialize_checkm,init_QC,finalize_QC,QC_report
 
 
 


### PR DESCRIPTION
generate read stats for all steps via the rule **read_stats**:

Other modifications to the workflow:
- Optional duplication rule instead of compress
- Control QC steps via the list _processed_steps_ 