### PR TITLE
correction of double counting reads

### DIFF
--- a/atlas/rules/assemble.snakefile
+++ b/atlas/rules/assemble.snakefile
@@ -129,7 +129,7 @@ rule read_stats:
 
         if paired_end:
             n_reads_pe, n_bases_pe = get_read_stats('pe', "in1={0} in2={1}".format(*input))
-
+            n_reads_pe= n_reads_pe/2
             headers= ['Sample', 'Step', 'Total_Reads', 'Total_Bases',
                       'Reads_pe', 'Bases_pe', 'Reads_se', 'Bases_se',
                       'Timestamp']


### PR DESCRIPTION
reformat counts gives the sum of R1 and R2 reads.
For me it makes less sens to count them both.