### PR TITLE
Assembly

### DIFF
--- a/atlas/conf.py
+++ b/atlas/conf.py
@@ -84,10 +84,9 @@ def make_config(config, path, data_type, database_dir, threads, assembler):
     conf["preprocess_minimum_passing_read_length"] = PREPROCESS_MINIMUM_PASSING_READ_LENGTH
     conf["preprocess_minimum_base_frequency"] = PREPROCESS_MINIMUM_BASE_FREQUENCY
 
-    conf["perform_error_correction"] = True
     conf["deduplicate"] = False
     conf["error_correction_overlapping_pairs"] = True
-
+    conf["assembly_preprocessing_steps"]=['normalized','errorcorr','merged']
 
     conf["contaminant_references"] = {"rRNA":os.path.join(database_dir, RRNA),
                                       "PhiX":os.path.join(database_dir, PHIX)}

--- a/atlas/rules/assemble.snakefile
+++ b/atlas/rules/assemble.snakefile
@@ -558,10 +558,10 @@ rule normalize_coverage_across_kmers:
 
 rule error_correction:
     input:
-        expand("{{sample}}/assembly/reads/{previous_steps}_{fraction}.fastq.gz",
+        expand("{{sample}}/assembly/reads/{{previous_steps}}_{fraction}.fastq.gz",
             fraction=interleaved_fractions)
     output:
-        temp(expand("{{sample}}/assembly/reads/{previous_steps}.errorcorr_{fraction}.fastq.gz",
+        temp(expand("{{sample}}/assembly/reads/{{previous_steps}}.errorcorr_{fraction}.fastq.gz",
             fraction=interleaved_fractions))
     benchmark:
         "logs/benchmarks/error_correction/{sample}.txt"
@@ -590,10 +590,10 @@ rule error_correction:
 
 rule merge_pairs:
     input:
-        expand("{{sample}}/assembly/reads/{previous_steps}_{fraction}.fastq.gz",
+        expand("{{sample}}/assembly/reads/{{previous_steps}}_{fraction}.fastq.gz",
             fraction=interleaved_fractions)
     output:
-        temp(expand("{{sample}}/assembly/reads/{previous_steps}.merged_{fraction}.fastq.gz",
+        temp(expand("{{sample}}/assembly/reads/{{previous_steps}}.merged_{fraction}.fastq.gz",
             fraction=interleaved_fractions)),
         insert_size_hist="{sample}/sequence_quality_control/read_stats/insert_size_hsit.txt",
     threads:
@@ -628,7 +628,7 @@ rule merge_pairs:
 if config.get("assembler", "megahit") == "megahit":
     rule run_megahit:
         input:
-            expand("{{sample}}/assembly/reads/{assembly_preprocessing_steps}_{fraction}.fastq.gz",
+            expand("{{sample}}/assembly/reads/{{assembly_preprocessing_steps}}_{fraction}.fastq.gz",
             fraction=interleaved_fractions,assembly_preprocessing_steps=assembly_preprocessing_steps)
         output:
             temp("{sample}/assembly/{sample}_prefilter.contigs.fa")
@@ -685,7 +685,7 @@ if config.get("assembler", "megahit") == "megahit":
 else:
     rule run_spades:
         input:
-            expand("{{sample}}/assembly/reads/{assembly_preprocessing_steps}_{fraction}.fastq.gz",
+            expand("{{sample}}/assembly/reads/{{assembly_preprocessing_steps}}_{fraction}.fastq.gz",
             fraction=interleaved_fractions,assembly_preprocessing_steps=assembly_preprocessing_steps)
         output:
             temp("{sample}/assembly/contigs.fasta")

--- a/atlas/rules/assemble.snakefile
+++ b/atlas/rules/assemble.snakefile
@@ -594,8 +594,7 @@ rule merge_pairs:
             fraction=interleaved_fractions)
     output:
         temp(expand("{{sample}}/assembly/reads/{{previous_steps}}.merged_{fraction}.fastq.gz",
-            fraction=interleaved_fractions)),
-        insert_size_hist="{sample}/sequence_quality_control/read_stats/insert_size_hsit.txt",
+            fraction=interleaved_fractions))
     threads:
         config.get("threads", 1)
     resources:
@@ -616,7 +615,7 @@ rule merge_pairs:
         """
             {SHPFXM} bbmerge.sh -Xmx{resources.mem}G threads={threads} \
             in1={input[0]} in2={input[1]} outmerged={wildcards.sample}_merged_pairs.fastq.gz outu={output[0]} outu2={output[1]} \
-            {params.flags} k={params.kmer} extend2={params.extend2} ihist={output.insert_size_hist} 2> {log}
+            {params.flags} k={params.kmer} extend2={params.extend2} 2> {log}
 
             cat {wildcards.sample}_merged_pairs.fastq.gz {input[2]} > {output[2]} 2>> {log}
 

--- a/atlas/rules/assemble.snakefile
+++ b/atlas/rules/assemble.snakefile
@@ -313,6 +313,64 @@ if len(config.get("contaminant_references", {}).keys()) > 0:
             "{SHPFXS} cat {input} > {output}"
 
 
+if config.get('deduplicate',False):
+    processed_steps += ['deduplicated']
+    rule deduplicate:
+        input:
+            expand("{{sample}}/sequence_quality_control/{{sample}}_{step}_{fraction}.fastq.gz",
+                step=processed_steps[-2], fraction=multifile_fractions)
+        output:
+            temp(expand("{{sample}}/sequence_quality_control/{{sample}}_{step}_{fraction}.fastq.gz",
+                fraction=multifile_fractions, step=processed_steps[-1]))
+        benchmark:
+            "logs/benchmarks/deduplicate/{sample}.txt"
+        params:
+            has_paired_end_files= lambda wc, input: "t" if hasattr(input,'R1') else "f",
+            input_paired = lambda wc, input: "in=%s in2=%s" % (input.R1, input.R2) if hasattr(input,'R1') else "null",
+            output_single = lambda wc,output,input: "out=%s" % output[1] if hasattr(input,'R1') else "out=%s" % output[0],
+            output_paired = lambda wc,output: "out=%s" % output[0],
+            dupesubs= config.get('DUPLICATES_ALLOW_SUBSTITUTIONS', 0)
+        log:
+            "{sample}/logs/{sample}_deduplicate.log"
+        conda:
+            "%s/required_packages.yaml" % CONDAENV
+        threads:
+            config.get("threads", 1)
+        resources:
+            mem = config.get("java_mem", JAVA_MEM)
+        shell:
+            """
+            if [ {params.input_single} != "null" ];
+            then
+            {SHPFXM} clumpify.sh \
+            {params.input_single} \
+            {params.output_single} \
+            overwrite=true\
+            dedupe=t \
+            dupesubs={params.dupesubs} \
+            threads={threads} \
+            -Xmx{resources.mem}G 2> {log}
+
+            fi
+
+
+            if [ {params.has_paired_end_files} = "t" ];
+            then
+            
+            {SHPFXM} clumpify.sh \
+            {params.input_paired} \
+            {params.output_paired} \
+            overwrite=true\
+            dedupe=t \
+            dupesubs={params.dupesubs} \
+            threads={threads} \
+            -Xmx{resources.mem}G 2>> {log}
+
+            fi
+
+            """
+
+
 processed_steps += ['QC']
 
 rule get_QC_reads:
@@ -425,62 +483,21 @@ got: {n} files:\n{}
 # may be we can put the following code in a separate snakefile
 
 
-if config.get('deduplicate',False):
-    processed_steps += ['deduplicated']
-    rule deduplicate:
-        input:
-            expand("{{sample}}/sequence_quality_control/{{sample}}_{step}_{fraction}.fastq.gz",
-                step=processed_steps[-2], fraction=multifile_fractions)
-        output:
-            temp(expand("{{sample}}/sequence_quality_control/{{sample}}_{step}_{fraction}.fastq.gz",
-                fraction=multifile_fractions, step=processed_steps[-1]))
-        benchmark:
-            "logs/benchmarks/deduplicate/{sample}.txt"
-        params:
-            has_paired_end_files= lambda wc, input: "t" if hasattr(input,'R1') else "f",
-            input_paired = lambda wc, input: "in=%s in2=%s" % (input.R1, input.R2) if hasattr(input,'R1') else "null",
-            output_single = lambda wc,output,input: "out=%s" % output[1] if hasattr(input,'R1') else "out=%s" % output[0],
-            output_paired = lambda wc,output: "out=%s" % output[0],
-            dupesubs= config.get('DUPLICATES_ALLOW_SUBSTITUTIONS', 0)
-        log:
-            "{sample}/logs/{sample}_deduplicate.log"
-        conda:
-            "%s/required_packages.yaml" % CONDAENV
-        threads:
-            config.get("threads", 1)
-        resources:
-            mem = config.get("java_mem", JAVA_MEM)
-        shell:
-            """
-            if [ {params.input_single} != "null" ];
-            then
-            {SHPFXM} clumpify.sh \
-            {params.input_single} \
-            {params.output_single} \
-            overwrite=true\
-            dedupe=t \
-            dupesubs={params.dupesubs} \
-            threads={threads} \
-            -Xmx{resources.mem}G 2> {log}
+# define which steps are defined before asslembly and in which order
 
-            fi
+possible_assembly_preprocessing_steps=['normalized','errorcorr','merged']
 
+requested_steps= list(config['assembly_preprocessing_steps'])
 
-            if [ {params.has_paired_end_files} = "t" ];
-            then
-            
-            {SHPFXM} clumpify.sh \
-            {params.input_paired} \
-            {params.output_paired} \
-            overwrite=true\
-            dedupe=t \
-            dupesubs={params.dupesubs} \
-            threads={threads} \
-            -Xmx{resources.mem}G 2>> {log}
+for step in requested_steps:
+	if not step in possible_assembly_preprocessing_steps:
+		raise Exception("Requesting unknown step, {} before assembly. Choose only steps from {}".format(step,possible_assembly_preprocessing_steps))
+	if step=='merged' and not paired_end:
+		warnings.warn("""Skip: merging of pairs before assembly, because reads are single-ended. 
+			You can remove the "merge" from assembly_preprocessing_steps  in the config file""")
+		requested_steps.remove(step)
 
-            fi
-
-            """
+assembly_preprocessing_steps=".".join(requested_steps)
 
 
 
@@ -488,8 +505,8 @@ rule normalize_coverage_across_kmers:
     input:
         unpack(get_quality_controlled_reads) #expect SE or R1,R2 or R1,R2,SE
     output:
-        expand("{{sample}}/sequence_quality_control/{{sample}}_normalized_{fraction}.fastq.gz",
-                fraction=interleaved_fractions)
+        temp(expand("{{sample}}/assembly/reads/normalized_{fraction}.fastq.gz",
+                fraction=interleaved_fractions))
     benchmark:
         "logs/benchmarks/normalization/{sample}.txt"
     params:
@@ -539,84 +556,80 @@ rule normalize_coverage_across_kmers:
 
             """
 
-if config.get("perform_error_correction", True):
-    processed_steps += ['errcor']
-    rule error_correction:
-        input:
-            expand("{{sample}}/sequence_quality_control/{{sample}}_{step}_{fraction}.fastq.gz",
-                step=processed_steps[-2], fraction=multifile_fractions)
-        output:
-            temp(expand("{{sample}}/sequence_quality_control/{{sample}}_{step}_{fraction}.fastq.gz",
-                fraction=multifile_fractions, step=processed_steps[-1]))
-        benchmark:
-            "logs/benchmarks/error_correction/{sample}.txt"
-        log:
-            "{sample}/logs/{sample}_error_correction.log"
-        conda:
-            "%s/required_packages.yaml" % CONDAENV
-        resources:
-            mem = config.get("java_mem", JAVA_MEM)
-        params:
-            inputs=lambda wc,input: "in1={0},{2} in2={1}".format(*input) if paired_end else "in={0}".format(*input),
-            outputs=lambda wc,output: "out1={0},{2} out2={1}".format(*output) if paired_end else "out={0}".format(*output)
-        threads:
-            config.get("threads", 1)
-        shell:
-            """
-                {SHPFXM} tadpole.sh -Xmx{resources.mem}G \
-                   prealloc=1 \
-                   {params.inputs} \
-                   {params.outputs} \
-                   mode=correct \
-                   threads={threads} \
-                   ecc=t ecco=t 2>> {log}
-            """
+rule error_correction:
+    input:
+        expand("{{sample}}/assembly/reads/{previous_steps}_{fraction}.fastq.gz",
+            fraction=interleaved_fractions)
+    output:
+        temp(expand("{{sample}}/assembly/reads/{previous_steps}.errorcorr_{fraction}.fastq.gz",
+            fraction=interleaved_fractions))
+    benchmark:
+        "logs/benchmarks/error_correction/{sample}.txt"
+    log:
+        "{sample}/logs/{sample}_error_correction.log"
+    conda:
+        "%s/required_packages.yaml" % CONDAENV
+    resources:
+        mem = config.get("java_mem", JAVA_MEM)
+    params:
+        inputs=lambda wc,input: "in1={0},{2} in2={1}".format(*input) if paired_end else "in={0}".format(*input),
+        outputs=lambda wc,output: "out1={0},{2} out2={1}".format(*output) if paired_end else "out={0}".format(*output)
+    threads:
+        config.get("threads", 1)
+    shell:
+        """
+            {SHPFXM} tadpole.sh -Xmx{resources.mem}G \
+               prealloc=1 \
+               {params.inputs} \
+               {params.outputs} \
+               mode=correct \
+               threads={threads} \
+               ecc=t ecco=t 2>> {log}
+        """
 
-if config.get("merge_pairs", True):
-    if paired_end:
-        processed_steps += ['merged']
 
-        rule merge_pairs:
-            input:
-                expand("{{sample}}/sequence_quality_control/{{sample}}_{step}_{fraction}.fastq.gz",
-                    step=processed_steps[-2],fraction=multifile_fractions)
-            output:
-                temp(expand("{{sample}}/sequence_quality_control/{{sample}}_{step}_{fraction}.fastq.gz",
-                    fraction=multifile_fractions,step=processed_steps[-1])),
-                insert_size_hist="{sample}/sequence_quality_control/read_stats/insert_size_hsit.txt",
-            threads:
-                config.get("threads", 1)
-            resources:
-                mem = config.get("java_mem", JAVA_MEM)
-            conda:
-                "%s/required_packages.yaml" % CONDAENV
-            log:
-                "{sample}/logs/{sample}_merge_pairs.log"
-            benchmark:
-                "logs/benchmarks/merge_pairs/{sample}.txt"
-            shadow:
-                "shallow"
-            params:
-                kmer = config.get("merging_k", MERGING_K),
-                extend2 = config.get("merging_extend2", MERGING_EXTEND2),
-                flags = config.get("merging_flags", MERGING_FLAGS)
-            shell:
-                """
-                    {SHPFXM} bbmerge.sh -Xmx{resources.mem}G threads={threads} \
-                    in1={input[0]} in2={input[1]} outmerged={wildcards.sample}_merged_pairs.fastq.gz outu={output[0]} outu2={output[1]} \
-                    {params.flags} k={params.kmer} extend2={params.extend2} ihist={output.insert_size_hist} 2> {log}
+rule merge_pairs:
+    input:
+        expand("{{sample}}/assembly/reads/{previous_steps}_{fraction}.fastq.gz",
+            fraction=interleaved_fractions)
+    output:
+        temp(expand("{{sample}}/assembly/reads/{previous_steps}.merged_{fraction}.fastq.gz",
+            fraction=interleaved_fractions)),
+        insert_size_hist="{sample}/sequence_quality_control/read_stats/insert_size_hsit.txt",
+    threads:
+        config.get("threads", 1)
+    resources:
+        mem = config.get("java_mem", JAVA_MEM)
+    conda:
+        "%s/required_packages.yaml" % CONDAENV
+    log:
+        "{sample}/logs/{sample}_merge_pairs.log"
+    benchmark:
+        "logs/benchmarks/merge_pairs/{sample}.txt"
+    shadow:
+        "shallow"
+    params:
+        kmer = config.get("merging_k", MERGING_K),
+        extend2 = config.get("merging_extend2", MERGING_EXTEND2),
+        flags = config.get("merging_flags", MERGING_FLAGS)
+    shell:
+        """
+            {SHPFXM} bbmerge.sh -Xmx{resources.mem}G threads={threads} \
+            in1={input[0]} in2={input[1]} outmerged={wildcards.sample}_merged_pairs.fastq.gz outu={output[0]} outu2={output[1]} \
+            {params.flags} k={params.kmer} extend2={params.extend2} ihist={output.insert_size_hist} 2> {log}
 
-                    cat {wildcards.sample}_merged_pairs.fastq.gz {input[2]} > {output[2]} 2>> {log}
+            cat {wildcards.sample}_merged_pairs.fastq.gz {input[2]} > {output[2]} 2>> {log}
 
-                """
-    else:
-        warnings.warn('Skip: merging of pairs, because reads are single-ended. You can deactivate the "merge_pairs" in the config file')
+        """
+
+
 
 
 if config.get("assembler", "megahit") == "megahit":
     rule run_megahit:
         input:
-            rules.normalize_coverage_across_kmers.output
+            expand("{{sample}}/assembly/reads/{assembly_preprocessing_steps}_{fraction}.fastq.gz",
+            fraction=interleaved_fractions,assembly_preprocessing_steps=assembly_preprocessing_steps)
         output:
             temp("{sample}/assembly/{sample}_prefilter.contigs.fa")
         benchmark:
@@ -672,7 +685,8 @@ if config.get("assembler", "megahit") == "megahit":
 else:
     rule run_spades:
         input:
-            rules.normalize_coverage_across_kmers.output
+            expand("{{sample}}/assembly/reads/{assembly_preprocessing_steps}_{fraction}.fastq.gz",
+            fraction=interleaved_fractions,assembly_preprocessing_steps=assembly_preprocessing_steps)
         output:
             temp("{sample}/assembly/contigs.fasta")
         benchmark:

--- a/atlas/rules/assemble.snakefile
+++ b/atlas/rules/assemble.snakefile
@@ -627,7 +627,7 @@ rule merge_pairs:
 if config.get("assembler", "megahit") == "megahit":
     rule run_megahit:
         input:
-            expand("{{sample}}/assembly/reads/{{assembly_preprocessing_steps}}_{fraction}.fastq.gz",
+            expand("{{sample}}/assembly/reads/{assembly_preprocessing_steps}_{fraction}.fastq.gz",
             fraction=interleaved_fractions,assembly_preprocessing_steps=assembly_preprocessing_steps)
         output:
             temp("{sample}/assembly/{sample}_prefilter.contigs.fa")
@@ -684,7 +684,7 @@ if config.get("assembler", "megahit") == "megahit":
 else:
     rule run_spades:
         input:
-            expand("{{sample}}/assembly/reads/{{assembly_preprocessing_steps}}_{fraction}.fastq.gz",
+            expand("{{sample}}/assembly/reads/{sassembly_preprocessing_steps}_{fraction}.fastq.gz",
             fraction=interleaved_fractions,assembly_preprocessing_steps=assembly_preprocessing_steps)
         output:
             temp("{sample}/assembly/contigs.fasta")

--- a/atlas/rules/assemble.snakefile
+++ b/atlas/rules/assemble.snakefile
@@ -325,10 +325,11 @@ if config.get('deduplicate',False):
         benchmark:
             "logs/benchmarks/deduplicate/{sample}.txt"
         params:
-            has_paired_end_files= lambda wc, input: "t" if hasattr(input,'R1') else "f",
-            input_paired = lambda wc, input: "in=%s in2=%s" % (input.R1, input.R2) if hasattr(input,'R1') else "null",
-            output_single = lambda wc,output,input: "out=%s" % output[1] if hasattr(input,'R1') else "out=%s" % output[0],
-            output_paired = lambda wc,output: "out=%s" % output[0],
+            has_paired_end_files= lambda wc, input: "t" if paired_end else "f",
+            input_single = lambda wc, input: "in=%s" % input[2] if paired_end else "in=%s" % input[0],
+            input_paired = lambda wc, input: "in=%s in2=%s" % (input[0], input[1]) if paired_end else "null",
+            output_single = lambda wc,output,input: "out=%s" % output[2] if paired_end else "out=%s" % output[0],
+            output_paired = lambda wc,output: "out=%s out2=%s" % (output[0],output[1]) if paired_end else "null",
             dupesubs= config.get('DUPLICATES_ALLOW_SUBSTITUTIONS', 0)
         log:
             "{sample}/logs/{sample}_deduplicate.log"
@@ -340,8 +341,7 @@ if config.get('deduplicate',False):
             mem = config.get("java_mem", JAVA_MEM)
         shell:
             """
-            if [ {params.input_single} != "null" ];
-            then
+
             {SHPFXM} clumpify.sh \
             {params.input_single} \
             {params.output_single} \
@@ -351,7 +351,6 @@ if config.get('deduplicate',False):
             threads={threads} \
             -Xmx{resources.mem}G 2> {log}
 
-            fi
 
 
             if [ {params.has_paired_end_files} = "t" ];

--- a/atlas/rules/assemble.snakefile
+++ b/atlas/rules/assemble.snakefile
@@ -518,7 +518,7 @@ rule normalize_coverage_across_kmers:
         input_paired = lambda wc, input: "in=%s in2=%s" % (input.R1, input.R2) if hasattr(input,'R1') else "null",
         extra_paired = lambda wc, input: "extra=%s" % input.se if hasattr(input,'se') else "",
         output_single = lambda wc,output,input: "out=%s" % output[2] if hasattr(input,'R1') else "out=%s" % output[0],
-        output_paired = lambda wc,output: "out=%s out2=%s" % (output[0],output[1]),
+        output_paired = lambda wc,output: "out=%s out2=%s" % (output[0],output[1]) if hasattr(input,'R1') else "",
         interleaved = "f" #lambda wc, input: "t" if (wc.fraction=='pe') else "f"   # I don't know how to handle interleaved files at this stage
     log:
         "{sample}/logs/{sample}_normalization.log"


### PR DESCRIPTION
I'm sorry there where still some bugs in #40 I corrected them here and tested them on paired and single end dummy data. I pushed them directly to the master to resolve the bugs. 

Now we have:

 -trimming
 - decontamination
 - deduplication (optional)

QC reads:

preprocessing assembly:
 - normalization
 - errorcorr
 - merging

order can be changed via the list in the config file.

However the QC reads are maped to the contigs, which alow also vairant calling. 

@brwnj  what do you think of that?  
