### PR TITLE
Silas

### DIFF
--- a/atlas/envs/required_packages.yaml
+++ b/atlas/envs/required_packages.yaml
@@ -5,7 +5,7 @@ channels:
     - r
 dependencies:
     - python=3.5
-    - bbmap=37.17
+    - bbmap=37.75
     - bzip2=1.0.6
     - click=6.7
     - diamond=0.9.10

--- a/atlas/rules/assemble.snakefile
+++ b/atlas/rules/assemble.snakefile
@@ -194,7 +194,7 @@ if config.get("assembler", "megahit") == "megahit":
             low_local_ratio = config.get("megahit_low_local_ratio", MEGAHIT_LOW_LOCAL_RATIO),
             min_contig_len = config.get("prefilter_minimum_contig_length", PREFILTER_MINIMUM_CONTIG_LENGTH),
             outdir = lambda wc, output: os.path.dirname(output[0]),
-            inputs=lambda wc,input: "-1 {0} -2 {1} --read {2}".format(*input) if len(input)==2 else "--read {0}".format(*input)
+            inputs=lambda wc,input: "-1 {0} -2 {1} --read {2}".format(*input) if paired_end else "--read {0}".format(*input)
         conda:
             "%s/required_packages.yaml" % CONDAENV
         threads:
@@ -239,7 +239,7 @@ else:
         benchmark:
             "logs/benchmarks/assembly/{sample}.txt"
         params:
-            inputs=lambda wc,input: "-1 {0} -2 {1} -s {2}".format(*input) if len(input) == 3 else "-s {0}".format(*input),
+            inputs=lambda wc,input: "-1 {0} -2 {1} -s {2}".format(*input) if paired_end else "-s {0}".format(*input),
             k = config.get("spades_k", SPADES_K),
             outdir = lambda wc: "{sample}/assembly".format(sample=wc.sample),
             #min_length=config.get("prefilter_minimum_contig_length", PREFILTER_MINIMUM_CONTIG_LENGTH)

--- a/atlas/rules/qc.snakefile
+++ b/atlas/rules/qc.snakefile
@@ -499,7 +499,7 @@ if paired_end:
                 sample= insert_file.split(os.path.sep)[0]
 
                 data = parse_comments(insert_file)
-                data = pd.Series(data)[['Avg','Median','Mode','STDev','PercentOfPairs']]
+                data = pd.Series(data)[['Mean','Median','Mode','STDev','PercentOfPairs']]
 
                 Stats[sample]=data
 

--- a/atlas/rules/qc.snakefile
+++ b/atlas/rules/qc.snakefile
@@ -409,7 +409,8 @@ if paired_end:
                    {params.flags} k={params.kmer} \
                    extend2={params.extend2} \
                    ihist={output.ihist} merge=f \
-                   mininsert0=35 minoverlap0=8 2> >(tee {log})
+                   mininsert0=35 minoverlap0=8 \
+                   prealloc=t prefilter=t 2> >(tee {log})
                 
                 readlength.sh in={input.R1} in2={input.R2} out={output.read_length} 2> >(tee {log})
             """


### PR DESCRIPTION
Updated to newest version of BBmap. The old one gave me some bugs.

39154d7: Change critical bug in assembly with megahit:

Megahit took only R1 files when it should have taken all reads. This leads to very low assembly performance. I'm sorry for this. 
