### PR TITLE
Corrects ambigous bases

### DIFF
--- a/atlas/rules/qc.snakefile
+++ b/atlas/rules/qc.snakefile
@@ -102,6 +102,8 @@ rule init_QC:
         """reformat.sh {params.inputs} \
         interleaved={params.interleaved} \
         {params.outputs} \
+        iupacToN=t \
+        touppercase=t \
         qout=33 \
         overwrite=true \
         verifypaired={params.verifypaired} \


### PR DESCRIPTION
I encountered [ambiguous bases](http://www.dnabaser.com/articles/IUPAC%20ambiguity%20codes.html) in the Cami dataset, which lead to errors in bbnorm. which didn't crash, but removed probably 90% of my reads. Applying `atlas QC` on the cami reads removed halve of the reads in the bbduck step. 

I suggest to convert them to N during the initial step.