### PR TITLE
Spades 3.12

### DIFF
--- a/atlas/default_values.py
+++ b/atlas/default_values.py
@@ -106,7 +106,7 @@ def make_default_config():
 
     conf["deduplicate"] = True
     conf["error_correction_overlapping_pairs"] = True
-    conf["merge_pairs_before_assembly"] = True
+
 
     conf["contaminant_max_indel"] = CONTAMINANT_MAX_INDEL
     conf["contaminant_min_ratio"] = CONTAMINANT_MIN_RATIO
@@ -117,10 +117,15 @@ def make_default_config():
     conf["duplicates_only_optical"] = DUPLICATES_ONLY_OPTICAL
     conf["duplicates_allow_substitutions"] = DUPLICATES_ALLOW_SUBSTITUTIONS
 
+
+    conf["normalize_reads_before_assembly"] = True
     conf["normalization_kmer_length"] = NORMALIZATION_KMER_LENGTH
     conf["normalization_target_depth"] = NORMALIZATION_TARGET_DEPTH
     conf["normalization_minimum_kmers"] = NORMALIZATION_MINIMUM_KMERS
 
+    conf["error_correction_before_assembly"] =  True
+    
+    conf["merge_pairs_before_assembly"] =  True
     conf["merging_k"] = MERGING_K
     conf["merging_extend2"] = MERGING_EXTEND2
     conf["merging_flags"]  = MERGING_FLAGS
@@ -140,6 +145,7 @@ def make_default_config():
     conf["prefilter_minimum_contig_length"] = PREFILTER_MINIMUM_CONTIG_LENGTH
     conf["spades_k"] = SPADES_K
     conf["spades_preset"] = 'meta'
+    conf["spades_skip_BayesHammer"] = False
     conf["minimum_average_coverage"] = MINIMUM_AVERAGE_COVERAGE
     conf["minimum_percent_covered_bases"] = MINIMUM_PERCENT_COVERED_BASES
     conf["minimum_mapped_reads"] = MINIMUM_MAPPED_READS

--- a/atlas/default_values.py
+++ b/atlas/default_values.py
@@ -27,8 +27,11 @@ DUPLICATES_ONLY_OPTICAL = False
 DUPLICATES_ALLOW_SUBSTITUTIONS = 2
 
 NORMALIZATION_KMER_LENGTH = 21
-NORMALIZATION_TARGET_DEPTH = 100
-NORMALIZATION_MINIMUM_KMERS = 15
+
+# almost no filtering unless grossly over-represented
+NORMALIZATION_TARGET_DEPTH = 10000 #500
+# allow very low represented kmers to remain
+NORMALIZATION_MINIMUM_KMERS = 3 #15
 
 ASSEMBLY_MEMORY = 50
 ASSEMBLY_THREADS = 8
@@ -40,13 +43,16 @@ MEGAHIT_MERGE_LEVEL = "20,0.98"
 MEGAHIT_PRUNE_LEVEL = 2
 MEGAHIT_LOW_LOCAL_RATIO = 0.2
 SPADES_K = "auto"
-PREFILTER_MINIMUM_CONTIG_LENGTH = 500
-MINIMUM_CONTIG_LENGTH = 2200
+# basically no filtering after assembly
+PREFILTER_MINIMUM_CONTIG_LENGTH = 200 #500
+# this is bumped up slightly to filter non-merged R1 and R2 sequences
+MINIMUM_CONTIG_LENGTH = 300 #2200
 
-MINIMUM_AVERAGE_COVERAGE = 5
-MINIMUM_PERCENT_COVERED_BASES = 40
+# leave all contigs
+MINIMUM_AVERAGE_COVERAGE = 1 #5
+MINIMUM_PERCENT_COVERED_BASES = 20 #40
 MINIMUM_MAPPED_READS = 0
-CONTIG_TRIM_BP = 100
+CONTIG_TRIM_BP = 0  #100
 
 # bases
 MINIMUM_REGION_OVERLAP = 1
@@ -124,7 +130,7 @@ def make_default_config():
     conf["normalization_minimum_kmers"] = NORMALIZATION_MINIMUM_KMERS
 
     conf["error_correction_before_assembly"] =  True
-    
+
     conf["merge_pairs_before_assembly"] =  True
     conf["merging_k"] = MERGING_K
     conf["merging_extend2"] = MERGING_EXTEND2
@@ -146,6 +152,7 @@ def make_default_config():
     conf["spades_k"] = SPADES_K
     conf["spades_preset"] = 'meta'
     conf["spades_skip_BayesHammer"] = False
+    conf["filter_contigs"] = True
     conf["minimum_average_coverage"] = MINIMUM_AVERAGE_COVERAGE
     conf["minimum_percent_covered_bases"] = MINIMUM_PERCENT_COVERED_BASES
     conf["minimum_mapped_reads"] = MINIMUM_MAPPED_READS

--- a/atlas/envs/required_packages.yaml
+++ b/atlas/envs/required_packages.yaml
@@ -15,6 +15,6 @@ dependencies:
     - prokka=1.12
     - pyyaml=3.12
     - samtools=1.3.1
-    - spades=3.11.0
+    - spades=3.12.0
     - sqlite=3.13.0
     - subread=1.5.3

--- a/atlas/template_config.yaml
+++ b/atlas/template_config.yaml
@@ -63,9 +63,9 @@ contaminant_ambiguous: best
 
 normalize_reads_before_assembly : true
 # target kmer depth
-normalization_target_depth: 100
+normalization_target_depth: 10000
 normalization_kmer_length: 21
-normalization_minimum_kmers: 15
+normalization_minimum_kmers: 3
 
 error_correction_before_assembly : true
 
@@ -104,16 +104,18 @@ spades_k: auto
 
 # Filtering
 #------------
-# trim contig tips
-contig_trim_bp: 20
-# filter out assembled noise
 prefilter_minimum_contig_length: 200
+# filter out assembled noise
+# this is more important for assemblys from megahit
+filter_contigs: true
+# trim contig tips
+contig_trim_bp: 0
 # require contigs to have read support
 minimum_average_coverage: 1
-minimum_percent_covered_bases: 40
+minimum_percent_covered_bases: 20
 minimum_mapped_reads: 0
 # after filtering
-minimum_contig_length: 200
+minimum_contig_length: 300
 
 
 ########################

--- a/atlas/template_config.yaml
+++ b/atlas/template_config.yaml
@@ -60,12 +60,17 @@ contaminant_ambiguous: best
 ########################
 # Pre-assembly-processing
 ########################
+
+normalize_reads_before_assembly : true
 # target kmer depth
 normalization_target_depth: 100
 normalization_kmer_length: 21
 normalization_minimum_kmers: 15
+
+error_correction_before_assembly : true
+
 # join R1 and R2 at overlap; unjoined reads are still utilized
-merge_pairs_before_assembly: true
+merge_pairs_before_assembly : true
 # extend reads while merging to this many nucleotides
 merging_extend2: 40
 # Iterations are performed until extend2 x iterations
@@ -94,6 +99,7 @@ megahit_preset: default
 
 # Spades
 #------------
+spades_skip_BayesHammer: False
 spades_k: auto
 
 # Filtering


### PR DESCRIPTION
Ads spades 3.12, which handles merged reads separately.
Added "loose parameters"
add options to individually toggle:
- normalization
- error_correction
- merging 
- error_correction of spades (BaysHammer), 
- filtering of contigs

added pythonic symlinks to reduce memory storage. 