### PR TITLE
Dev

### DIFF
--- a/atlas/rules/annotate.snakefile
+++ b/atlas/rules/annotate.snakefile
@@ -221,7 +221,7 @@ rule align_reads_to_renamed_contigs:
                out={output.sam} mappedonly=t threads={threads} bhist={output.bhist} \
                bqhist={output.bqhist} mhist={output.mhist} gchist={output.gchist} \
                statsfile={output.statsfile} covstats={output.covstats} mdtag=t xstag=fs nmtag=t \
-               sam=1.3 local=t ambiguous=all interleaved={params.interleaved} secondary=t ssao=t \
+               sam=1.3 local=t ambiguous=all interleaved={params.interleaved} secondary=t \
                maxsites={params.maxsites} 2> {log}"""
 
 

--- a/atlas/rules/assemble.snakefile
+++ b/atlas/rules/assemble.snakefile
@@ -515,7 +515,7 @@ rule align_reads_to_final_contigs:
                ref={input.fasta} \
                {params.input} \
                trimreaddescriptions=t \
-               outm={output.sam} \
+               out={output.sam} \
                {params.unmapped} \
                threads={threads} \
                pairlen={params.max_distance_between_pairs} \
@@ -528,6 +528,8 @@ rule align_reads_to_final_contigs:
                local=t \
                ambiguous={params.ambiguous} \
                secondary=t \
+               append=t \
+               machineout=t \
                maxsites={params.maxsites} \
                -Xmx{resources.java_mem}G \
                2> {log}

--- a/atlas/rules/assemble.snakefile
+++ b/atlas/rules/assemble.snakefile
@@ -528,7 +528,6 @@ rule align_reads_to_final_contigs:
                local=t \
                ambiguous={params.ambiguous} \
                secondary=t \
-               ssao=t \
                maxsites={params.maxsites} \
                -Xmx{resources.java_mem}G \
                2> {log}


### PR DESCRIPTION
Fixes #101 Fixes  #105 

- removes ssao, *critical*
- appends singletons reads to sam. 
- adds unmapped reads to sam file. -> statistics of pileup and assembly report are right.

mapped reads are calculated as: 

(mapped singletons + 2 x mapped pe) / (QC singletons + 2* QC paired end reads)

