### PR TITLE
Dev

### DIFF
--- a/atlas/Snakefile
+++ b/atlas/Snakefile
@@ -203,7 +203,8 @@ elif config.get("workflow", "complete") == "complete":
                 sample=SAMPLES),
             expand("{sample}/finished_assembly", sample=SAMPLES),
             REPORTS,
-            expand("{sample}/{sample}_annotations.txt", sample=SAMPLES),
+            "Genecatalog/genecatalog_finished"
+            #expand("{sample}/{sample}_annotations.txt", sample=SAMPLES),
 
 # checkpoint finished contigs, no annotation
     localrules: finish_assembly

--- a/atlas/__init__.py
+++ b/atlas/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 TAX_LEVELS = ["superkingdom", "phylum", "class", "order", "family", "genus", "species"]
 BLAST6 = [
     "qseqid",

--- a/atlas/rules/binning.snakefile
+++ b/atlas/rules/binning.snakefile
@@ -257,7 +257,7 @@ rule get_unique_cluster_attribution:
         if 0 in old_cluster_ids:
             old_cluster_ids.remove(0)
 
-        map_cluster_ids = dict(zip(old_cluster_ids, gen_names_for_range(len(old_cluster_ids), prefix="{sample}_{binner}_" )  ))
+        map_cluster_ids = dict(zip(old_cluster_ids, gen_names_for_range(len(old_cluster_ids), prefix="{sample}_{binner}_".format(**wildcards) )  ))
 
         new_d= d.map(map_cluster_ids)
         new_d.dropna(inplace=True)

--- a/atlas/rules/genecatalog.snakefile
+++ b/atlas/rules/genecatalog.snakefile
@@ -7,6 +7,8 @@ rule gene_catalog:
         "Genecatalog/gene_catalog.faa",
         "Genecatalog/counts/median_coverage.tsv",
         expand("Genecatalog/annotation/single_copy_genes_{domain}.tsv",domain=['bacteria','archaea'])
+    output:
+        temp(touch("Genecatalog/genecatalog_finished"))
 
 
 localrules: concat_genes

--- a/atlas/rules/genecatalog.snakefile
+++ b/atlas/rules/genecatalog.snakefile
@@ -298,7 +298,7 @@ rule align_reads_to_Genecatalog:
         sam = temp("Genecatalog/alignments/{sample}.sam")
     params:
         input = lambda wc, input : input_params_for_bbwrap(wc, input),
-        maxsites = 2,
+        maxsites = 4,
         ambiguous = 'all',
         minid = config['genecatalog']['minid'],
         maxindel = 1 # default 16000 good for genome deletions but not necessarily for alignment to contigs
@@ -320,14 +320,13 @@ rule align_reads_to_Genecatalog:
             ref={input.fasta} \
             {params.input} \
             trimreaddescriptions=t \
-            outm={output.sam} \
+            out={output.sam} \
             threads={threads} \
             minid={params.minid} \
             mdtag=t \
             xstag=fs \
             nmtag=t \
             sam=1.3 \
-            local=t \
             ambiguous={params.ambiguous} \
             secondary=t \
             saa=f \

--- a/atlas/rules/genecatalog.snakefile
+++ b/atlas/rules/genecatalog.snakefile
@@ -287,7 +287,7 @@ rule rename_gene_catalog:
                     protein.id = map_names[protein.name]
 
                     SeqIO.write(gene,fna,'fasta')
-                    SeqIO.write(gene,faa,'fasta')
+                    SeqIO.write(protein,faa,'fasta')
 
 
 rule align_reads_to_Genecatalog:

--- a/atlas/rules/genecatalog.snakefile
+++ b/atlas/rules/genecatalog.snakefile
@@ -442,6 +442,8 @@ rule predict_single_copy_genes:
         "%s/DASTool.yaml" % CONDAENV # needs pearl
     log:
         "logs/Genecatalog/annotation/predict_single_copy_genes_{domain}.log"
+    shadow:
+        "shallow"
     threads:
         config['threads']
     shell:

--- a/atlas/rules/genecatalog.snakefile
+++ b/atlas/rules/genecatalog.snakefile
@@ -457,7 +457,7 @@ rule predict_single_copy_genes:
         " {threads} "
         " 2> >(tee {log}) "
         " ; "
-        " mv {input[0]}.{wildcards.domain}.scg > {output}"
+        " mv {input[0]}.{wildcards.domain}.scg {output}"
 
 
 


### PR DESCRIPTION
Bug fixes in:
Binning workflow: 
- Renaming of genomes

Gene catalog:
- get gene_catalog.faa with amino acids
- predict single copy genes
- added gene catalog to the output of 'atlas assemble'
- temporarily removed gene annotation form output of 'atlas assemble'

I will work on a different branch to make annotation of the gene catalog instead of each gene in each sample. 

FYI @brwnj @sofie8